### PR TITLE
PLATFORM-3768 replace sku claim property with claimable boolean in catalog schema

### DIFF
--- a/docs/catalog/catalog-schema-v6.json
+++ b/docs/catalog/catalog-schema-v6.json
@@ -77,15 +77,8 @@
               }
             ]
           },
-          "claim": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "claimable": {
+            "type": "boolean"
           },
           "discover": {
             "type": "boolean"
@@ -110,7 +103,7 @@
           "name",
           "permissions",
           "price",
-          "claim",
+          "claimable",
           "discover"
         ]
       }

--- a/test/catalog-schema-v6/catalog.json
+++ b/test/catalog-schema-v6/catalog.json
@@ -21,7 +21,7 @@
       "brand": "SKNUPS",
       "discover": false,
       "tier": null,
-      "claim": null
+      "claimable": false
     },
     "TEST-CUBE-UNDISCOVERABLE-VIDEO": {
       "name": "Common Cube",
@@ -47,7 +47,7 @@
       "brand": "TEST",
       "discover": false,
       "tier": null,
-      "claim": null
+      "claimable": false
     },
     "TEST-CUBE-DISCOVERABLE-IMAGE": {
       "name": "Epic Cube",
@@ -70,7 +70,7 @@
       "brand": "TEST",
       "discover": true,
       "tier": null,
-      "claim": null
+      "claimable": false
     },
     "TEST-CUBE-DISCOVERABLE-VIDEO": {
       "name": "Mythic Cube",
@@ -96,7 +96,7 @@
       "brand": "TEST",
       "discover": true,
       "tier": null,
-      "claim": null
+      "claimable": false
     },
     "TEST-CUBE-UNDISCOVERABLE-SECONDARY-MEDIA": {
       "name": "Rare Cube",
@@ -134,7 +134,7 @@
       "brand": "TEST",
       "discover": false,
       "tier": null,
-      "claim": null
+      "claimable": false
     },
     "TEST-CUBE-DISCOVERABLE-SECONDARY-MEDIA": {
       "name": "Uncommon Cube",
@@ -173,7 +173,7 @@
       "brand": "TEST",
       "discover": true,
       "tier": null,
-      "claim": null
+      "claimable": false
     }
   },
   "brand": {


### PR DESCRIPTION
Given this is a non-breaking change, I propose to continue using catalog v6.

Also see: https://github.com/sknups/catalog-cloudfunctions-ts/pull/42