### PR TITLE
Platform 3763 - remove old permissions from catalog schema

### DIFF
--- a/docs/catalog/catalog-schema-v7.json
+++ b/docs/catalog/catalog-schema-v7.json
@@ -60,9 +60,6 @@
             "type": "array",
             "items": {
               "enum": [
-                "GIVEAWAY",
-                "SELL",
-                "DISCOVER",
                 "METAPLEX_MINT"
               ]
             }

--- a/test/catalog-schema-v7/catalog.json
+++ b/test/catalog-schema-v7/catalog.json
@@ -1,0 +1,183 @@
+{
+  "sku": {
+    "SKNUPS-UNDISCOVERABLE-IMAGE": {
+      "name": "DEEPS BACKPACK: DEEP COVER",
+      "description": "When you have things, they need to go places and the DEEPS backpacks will take you there. Deep COVER Edition will allow you to accomplish all your tasks, turning heads while doing so.",
+      "marketing": "When you have things, they need to go places and the DEEPS backpacks will take you there. Deep COVER Edition will allow you to accomplish all your tasks, turning heads while doing so.",
+      "media": {
+        "primary": {
+          "type": "IMAGE",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          }
+        },
+        "secondary": []
+      },
+      "price": null,
+      "maximum": 190,
+      "permissions": ["METAPLEX_MINT"],
+      "brand": "SKNUPS",
+      "discover": false,
+      "tier": null,
+      "claimable": false
+    },
+    "TEST-CUBE-UNDISCOVERABLE-VIDEO": {
+      "name": "Common Cube",
+      "description": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "marketing": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "media": {
+        "primary": {
+          "type": "VIDEO",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          },
+          "video": {
+            "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+          }
+        },
+        "secondary": []
+      },
+      "price": null,
+      "maximum": 1000000,
+      "permissions": [],
+      "brand": "TEST",
+      "discover": false,
+      "tier": null,
+      "claimable": false
+    },
+    "TEST-CUBE-DISCOVERABLE-IMAGE": {
+      "name": "Epic Cube",
+      "description": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "marketing": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "media": {
+        "primary": {
+          "type": "IMAGE",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          }
+        },
+        "secondary": []
+      },
+      "price": 1000,
+      "maximum": 1000,
+      "permissions": [],
+      "brand": "TEST",
+      "discover": true,
+      "tier": null,
+      "claimable": false
+    },
+    "TEST-CUBE-DISCOVERABLE-VIDEO": {
+      "name": "Mythic Cube",
+      "description": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "marketing": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "media": {
+        "primary": {
+          "type": "VIDEO",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          },
+          "video": {
+            "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+          }
+        },
+        "secondary": []
+      },
+      "price": 10000,
+      "maximum": 100,
+      "permissions": ["METAPLEX_MINT"],
+      "brand": "TEST",
+      "discover": true,
+      "tier": null,
+      "claimable": false
+    },
+    "TEST-CUBE-UNDISCOVERABLE-SECONDARY-MEDIA": {
+      "name": "Rare Cube",
+      "description": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "marketing": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "media": {
+        "primary": {
+          "type": "VIDEO",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          },
+          "video": {
+            "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+          }
+        },
+        "secondary": [
+          {
+            "type": "VIDEO",
+            "image": {
+              "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+              "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+              "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+            },
+            "video": {
+              "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+            }
+          }
+        ]
+      },
+      "price": null,
+      "maximum": 5000,
+      "permissions": ["METAPLEX_MINT"],
+      "brand": "TEST",
+      "discover": false,
+      "tier": null,
+      "claimable": false
+    },
+    "TEST-CUBE-DISCOVERABLE-SECONDARY-MEDIA": {
+      "name": "Uncommon Cube",
+      "description": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "marketing": "The only regular solid which tessellates Euclidean space: the hexahedron.  The ancients believed this caused the solidity of the Earth.",
+      "media": {
+        "primary": {
+          "type": "VIDEO",
+          "image": {
+            "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+            "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+            "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+          },
+          "video": {
+            "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+          }
+        },
+        "secondary": [
+          {
+            "type": "VIDEO",
+            "image": {
+              "jpeg": "${environment.assetsBucket}/sku.${skuCode}.discover.jpg",
+              "webp": "${environment.assetsBucket}/sku.${skuCode}.discover.webp",
+              "png": "${environment.assetsBucket}/sku.${skuCode}.discover.png"
+            },
+            "video": {
+              "mp4": "${environment.assetsBucket}/sku.${skuCode}.discover.mp4"
+            },
+            "link": "https://www.sknups.com"
+          }
+        ]
+      },
+      "price": null,
+      "maximum": 10000,
+      "permissions": ["METAPLEX_MINT"],
+      "brand": "TEST",
+      "discover": true,
+      "tier": null,
+      "claimable": false
+    }
+  },
+  "brand": {
+    "SKNUPS": { "name": "SKNUPS" },
+    "TEST": { "name": "TEST" }
+  }
+}

--- a/test/catalog-schema-v7/test-catalog.js
+++ b/test/catalog-schema-v7/test-catalog.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import { dirname, resolve } from 'path';
+
+import { deserialize } from '../deserialize.js';
+
+
+const __dirname = dirname(new URL(import.meta.url).pathname);
+
+const schema = fs.readFileSync(resolve(__dirname, '../../docs/catalog/catalog-schema-v7.json'));
+const example = fs.readFileSync(resolve(__dirname, './catalog.json'));
+
+describe('catalog-schema-v7.json', () => {
+  it('validates catalog.json', () => {
+    deserialize(example, schema);
+  });
+});


### PR DESCRIPTION
We are only removing old permissions, but legacy clients are dependant on the SELL permission. So I have  introduced a new schema version so we can add code to the retail catalog cloud functions to do the migration. 

Commit with diff https://github.com/sknups/schema/commit/879b1fdd078f6b09cc19d757d5074b3824431437